### PR TITLE
bulk dying and washing for ae2 cables

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -1575,7 +1575,7 @@ hash = "4b5a7c3488b572846f638cd0c1f31edffb64569b652b2c365059006cb695dd30"
 
 [[files]]
 file = "scripts/recipes/main.zs"
-hash = "08250413fcde97981dba81c0c3c4e5f401842c0cb99ee7cb89dcc062279ba015"
+hash = "45f16c8e86df3afbab374cbd0f420f274a795e84e0e743d11589821c413abb93"
 
 [[files]]
 file = "scripts/recipes/merge_phials.zs"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0dc86ec15a251a159c529365d2f0854c7d53c5c20a5a500ad2d5be512bd13f55"
+hash = "5cf395782f5328cb25f250194d92ae14321d5f40126ee4c00fab7fcebd530695"
 
 [versions]
 fabric = "0.16.9"

--- a/scripts/recipes/main.zs
+++ b/scripts/recipes/main.zs
@@ -23,3 +23,40 @@ GenericRecipesManager.INSTANCE.remove(<item:turtlematic:chunk_vial>);
 
 craftingTable.addShapeless("communism", <item:numismatics:cog>, [<item:spectrum:downstone_fragments>]);
 craftingTable.addShapeless("capitalism", <item:spectrum:downstone_fragments>, [<item:numismatics:cog>]);
+
+for cable in ["_smart_cable", "_covered_cable", "_glass_cable", "_covered_dense_cable", "_smart_dense_cable"] {
+    for color in ["white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray", "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black"] {
+        GenericRecipesManager.INSTANCE.addJsonRecipe("dye_blowing/ae2/"+color+"/"+cable, {
+            "type": "garnished:"+color+"_dye_blowing",
+            "ingredients": [
+                {
+                    "item": "ae2:fluix"+cable
+                }
+            ],
+            "results": [
+                {
+                    "item": "ae2:"+color+cable,
+                    "count": 1
+                }
+            ]
+        });
+    }
+}
+
+for cable in ["smart_cable", "covered_cable", "glass_cable", "covered_dense_cable", "smart_dense_cable"] {
+    GenericRecipesManager.INSTANCE.addJsonRecipe("washing/ae2/"+cable, {
+        "type": "create:splashing",
+        "ingredients": [
+            {
+                "tag": "ae2:"+cable
+            }
+        ],
+        "results": [
+            {
+                "item": "ae2:fluix_"+cable
+            }
+        ]
+    });
+}
+
+


### PR DESCRIPTION
closes #204 
adds recipes for bulk dying all the ae2 cables. and allows washing the back to fluix cables.